### PR TITLE
Fix save signal on custom ResetPasswordForm

### DIFF
--- a/docs/forms.rst
+++ b/docs/forms.rst
@@ -170,11 +170,11 @@ Used on `account_reset_password <views.html#password-reset-account-reset-passwor
     from allauth.account.forms import ResetPasswordForm
     class MyCustomResetPasswordForm(ResetPasswordForm):
 
-        def save(self):
+        def save(self, request):
 
             # Ensure you call the parent class's save.
             # .save() returns a string containing the email address supplied
-            email_address = super(MyCustomResetPasswordForm, self).save()
+            email_address = super(MyCustomResetPasswordForm, self).save(request)
 
             # Add your own processing here.
 


### PR DESCRIPTION
Docfix: The current save signal described doesn't work, I think this should fix it. See https://github.com/pennersr/django-allauth/issues/2277

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
